### PR TITLE
Hash password

### DIFF
--- a/commands/UsersHashPasswordController.php
+++ b/commands/UsersHashPasswordController.php
@@ -3,13 +3,12 @@
 namespace app\commands;
 
 use app\models\Usuario;
-use Yii;
 use yii\console\Controller;
 use yii\console\ExitCode;
 use yii\db\Transaction;
 
 /**
- * Hash password all users. Check if hash password is invalid and process
+ * Hash password users if hash is BCRYPT
  * @author Julian Murphy
  */
 class UsersHashPasswordController extends Controller
@@ -37,7 +36,7 @@ class UsersHashPasswordController extends Controller
 
                     foreach ($users as $user) {
                         if (password_needs_rehash($user->clave, PASSWORD_BCRYPT, ['cost' => 13])) {
-                            $user->clave = $user->clave;
+                            $user->setClave($user->clave);
                             $user->save(false);
 
                             $userProcessed++;

--- a/commands/UsersHashPasswordController.php
+++ b/commands/UsersHashPasswordController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace app\commands;
+
+use app\models\Usuario;
+use Yii;
+use yii\console\Controller;
+use yii\console\ExitCode;
+use yii\db\Transaction;
+
+/**
+ * Hash password all users. Check if hash password is invalid and process
+ * @author Julian Murphy
+ */
+class UsersHashPasswordController extends Controller
+{
+    public function actionIndex()
+    {
+            echo "Initialize command \n";
+            $batchSize = 100;
+            echo "Batch size $batchSize \n";
+
+            $totalUsers = Usuario::find()->count();
+            $totalBatches = ceil($totalUsers / $batchSize);
+            
+            $transaction = \Yii::$app->db->beginTransaction(
+                Transaction::SERIALIZABLE
+            );
+
+            try {
+                $userProcessed = 0;
+                for ($i = 0; $i < $totalBatches; $i++) {
+                    $users = Usuario::find()
+                        ->limit($batchSize)
+                        ->offset($i * $batchSize)
+                        ->all();
+
+                    foreach ($users as $user) {
+                        if (password_needs_rehash($user->clave, PASSWORD_BCRYPT, ['cost' => 13])) {
+                            $user->clave = $user->clave;
+                            $user->save(false);
+
+                            $userProcessed++;
+                            echo "Processed user: $user->nombreUsuario (ID: $user->id).\n";
+                        }
+                    }
+
+                }
+
+                $transaction->commit();
+                echo "Finish - processed: $userProcessed. \n";
+                return ExitCode::OK;
+
+            } catch (\Exception $e) {
+                $transaction->rollBack();
+                echo "Error to hash password: " . $e->getMessage() . "\n";
+                return ExitCode::UNSPECIFIED_ERROR;
+            }
+
+    }
+}

--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -118,7 +118,7 @@ class SiteController extends Controller {
                         //crear usuario
                         $usuario= new \app\models\Usuario();
                         $usuario->nombreUsuario=$modelRegistro->mail;
-                        $usuario->clave = $nuevaClave;
+                        $usuario->setClave($nuevaClave);
                         $usuario->idRol = \app\models\Rol::ROL_CERTIFICANTE;
 
                         if(!$usuario->save()) {
@@ -131,7 +131,7 @@ class SiteController extends Controller {
                         }
                         
                      } else {
-                         $modelRegistro->idUsuario0->clave = $nuevaClave;
+                         $modelRegistro->idUsuario0->setClave($nuevaClave);
                          if (!$modelRegistro->idUsuario0->save()) {
                             throw new \yii\base\UserException('no pudo actualizar la clave');
                          }

--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -2,6 +2,7 @@
 
 namespace app\controllers;
 
+use app\mail\UserRecoveryMail;
 use Yii;
 use yii\filters\AccessControl;
 use yii\web\Controller;
@@ -9,6 +10,7 @@ use yii\web\Response;
 use yii\filters\VerbFilter;
 use app\models\LoginForm;
 use app\models\ContactForm;
+use app\models\dto\UserMail;
 use kartik\mpdf\Pdf;
 
 class SiteController extends Controller {
@@ -95,57 +97,67 @@ class SiteController extends Controller {
         
     }
     
-    public function actionRecuperar() {
-        $model = new \app\models\RecuperarclaveForm();    //carga del modelo para utilizarlo luego
+    public function actionRecuperar()
+    {
+        $model = new \app\models\RecuperarclaveForm();
         $model->mail = '';
-        //print_r(\Yii::$app->request->post());
-        if ($model->load(Yii::$app->request->post())) {// si se realizo un submit del boton guardar
-            //print_r($model->email);
+
+        if ($model->load(Yii::$app->request->post())) {
+
             if (!$model->mail == '') {
 
                 $modelRegistro = \app\models\Persona::find()
                         ->where('mail="' . $model->mail . '"')
                         ->one();
+
                 if (!is_null($modelRegistro)) {
                     
-        $nuevaClave = substr(md5(time()), 0, 6);
-        /* Agrego token y dirección a Registro */
-        //print_r($modelRegistro);
-
+                    $nuevaClave = substr(md5(time()), 0, 6);
         
-                    if(is_null($modelRegistro->idUsuario)){
+                    if (is_null($modelRegistro->idUsuario)) {
                         //crear usuario
-                        $usuario=new \app\models\Usuario();
+                        $usuario= new \app\models\Usuario();
                         $usuario->nombreUsuario=$modelRegistro->mail;
-                        $usuario->clave=$nuevaClave;
-                        $usuario->idRol= \app\models\Rol::ROL_CERTIFICANTE;
-                        if(!$usuario->save()){
+                        $usuario->clave = $nuevaClave;
+                        $usuario->idRol = \app\models\Rol::ROL_CERTIFICANTE;
+
+                        if(!$usuario->save()) {
                             throw new \yii\base\UserException('no pudo guardar el usuario');
                         }
-                        $modelRegistro->idUsuario=$usuario->idUsuario;
+
+                        $modelRegistro->idUsuario = $usuario->idUsuario;
                         if(!$modelRegistro->save()){
                             throw new \yii\base\UserException('no pudo vincular el usuario');
                         }
                         
-                     }else{
+                     } else {
                          $modelRegistro->idUsuario0->clave = $nuevaClave;
-                         if(!$modelRegistro->idUsuario0->save()){
+                         if (!$modelRegistro->idUsuario0->save()) {
                             throw new \yii\base\UserException('no pudo actualizar la clave');
                          }
-                         
                      }
-                    return $this->envioMail($modelRegistro);
+
+                    UserRecoveryMail::send(
+                        UserMail::instantiateFromPerson(
+                            $modelRegistro,
+                            $nuevaClave
+                        )
+                    );
+
+                    return $this->render('mensaje', ['mensaje' => 'Se le ha enviado un Correo Electrónico. Revise su casilla']);
                 } else {
                     $model->addError('mail', 'el Correo es incorrecto o no está cargado. Si el problema persiste vuelva a registrarse');
                 }
             }
         }
+
         return $this->render('recuperar', ['model' => $model]);
     }
+
+    /**
+     * @deprecated maybe?
+     */
     protected function envioMail($modelRegistro,$masivo=false) {
-
-      
-
             Yii::$app->mailer->compose()
                     ->setFrom('wene@fi.uncoma.edu.ar')
                     ->setTo($modelRegistro->mail)

--- a/controllers/UsuarioController.php
+++ b/controllers/UsuarioController.php
@@ -120,8 +120,11 @@ public function behaviors() {
     {
         $model = $this->findModel($id);
 
-        if ($model->load(Yii::$app->request->post()) && $model->save()) {
-            return $this->redirect(['view', 'id' => $model->idUsuario]);
+        if ($model->load(Yii::$app->request->post())) {
+            $model->setClave($model->clave);
+            if ($model->save()) {
+                return $this->redirect(['view', 'id' => $model->idUsuario]);
+            }
         }
 
         return $this->render('set-password', [

--- a/controllers/UsuarioController.php
+++ b/controllers/UsuarioController.php
@@ -116,6 +116,19 @@ public function behaviors() {
         ]);
     }
 
+    public function actionSetPassword($id)
+    {
+        $model = $this->findModel($id);
+
+        if ($model->load(Yii::$app->request->post()) && $model->save()) {
+            return $this->redirect(['view', 'id' => $model->idUsuario]);
+        }
+
+        return $this->render('set-password', [
+            'model' => $model,
+        ]);
+    }
+
     /**
      * Deletes an existing Usuario model.
      * If deletion is successful, the browser will be redirected to the 'index' page.

--- a/controllers/UsuarioController.php
+++ b/controllers/UsuarioController.php
@@ -87,8 +87,12 @@ public function behaviors() {
     {
         $model = new Usuario();
 
-        if ($model->load(Yii::$app->request->post()) && $model->save()) {
-            return $this->redirect(['view', 'id' => $model->idUsuario]);
+        if (Yii::$app->request->isPost) {
+            $model->load(Yii::$app->request->post());
+            $model->setClave($model->clave);
+            if ($model->save()) {
+                return $this->redirect(['view', 'id' => $model->idUsuario]);
+            }
         }
 
         return $this->render('create', [

--- a/mail/UserRecoveryMail.php
+++ b/mail/UserRecoveryMail.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace app\mail;
+
+use app\models\dto\UserMail;
+use Yii;
+
+class UserRecoveryMail
+{
+    public static function send(UserMail $user)
+    {
+        Yii::$app->mailer->compose()
+            ->setFrom('wene@fi.uncoma.edu.ar')
+            ->setTo($user->email)
+            ->setSubject('Datos para descargar certificados del sistema wene')
+            ->setHtmlBody(
+                '<p>Estimadx, ' . $user->fullName.
+                ', este correo es enviado por el sistema wene (sistema de Certificados). Ingrese al siguiente ' .
+                \yii\helpers\Html::a('link', \yii\helpers\Url::base('https') . '/site/login?LoginForm[username]=' .
+                $user->username . '&LoginForm[password]=' . $user->plainPassword) .
+                ' para descargar y ver el historial de sus certificados. '.'</p>' .
+                '<p><b>Para próximos ingresos, su usuario es: ' . $user->username .
+                ' y su clave es: '. $user->plainPassword .'</p> <p>Muchas Gracias.</b><p>'
+            )
+            ->send();
+    }
+}

--- a/models/Usuario.php
+++ b/models/Usuario.php
@@ -31,11 +31,9 @@ class Usuario extends \yii\db\ActiveRecord implements \yii\web\IdentityInterface
         return self::findOne(['nombreUsuario' => $username]);
     }
 
-    public function beforeSave($insert)
+    public function setClave($password)
     {
-        $this->clave = Yii::$app->security->generatePasswordHash($this->clave);
-
-        return parent::beforeSave($insert);
+        $this->clave = Yii::$app->security->generatePasswordHash($password);
     }
 
     public function validatePassword($password)

--- a/models/Usuario.php
+++ b/models/Usuario.php
@@ -31,9 +31,16 @@ class Usuario extends \yii\db\ActiveRecord implements \yii\web\IdentityInterface
         return self::findOne(['nombreUsuario' => $username]);
     }
 
-    public function validatePassword($password) {
+    public function beforeSave($insert)
+    {
+        $this->clave = Yii::$app->security->generatePasswordHash($this->clave);
 
-        return $this->clave === $password;
+        return parent::beforeSave($insert);
+    }
+
+    public function validatePassword($password)
+    {
+        return Yii::$app->security->validatePassword($password, $this->clave);
     }
 
     public static function findIdentity($id) {

--- a/models/dto/UserMail.php
+++ b/models/dto/UserMail.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace app\models\dto;
+
+use app\models\Persona;
+
+class UserMail
+{
+    public string $fullName;
+    public string $email;
+    public string $plainPassword;
+    public string $username;
+
+    /**
+     * Use this method for instantiate an UserMail with plain-password to use into the recovery mail's
+     */
+    public static function instantiateFromPerson(Persona $person, string $plainPassword): self
+    {
+        $userMail = new self();
+        $userMail->email = $person->mail;
+        $userMail->fullName = $person->apellidoNombre;
+        $userMail->username = $person->idUsuario0->nombreUsuario;
+        $userMail->plainPassword= $plainPassword;
+
+        return $userMail;
+    }
+}

--- a/views/usuario/_form.php
+++ b/views/usuario/_form.php
@@ -14,8 +14,6 @@ use yii\widgets\ActiveForm;
 
     <?= $form->field($model, 'nombreUsuario')->textInput(['maxlength' => true]) ?>
 
-    <?= $form->field($model, 'clave')->textInput(['maxlength' => true]) ?>
-
     <?= $form->field($model, 'idRol')->dropDownList(\app\models\Rol::find()
             ->select(['nombre'])
             ->indexBy('idRol')

--- a/views/usuario/_form.php
+++ b/views/usuario/_form.php
@@ -19,7 +19,7 @@ use yii\widgets\ActiveForm;
             ->indexBy('idRol')
             ->column())?>
 
-    <?php if ($is_create): ?>
+    <?php if (isset($is_create) && $is_create): ?>
         <?= $form->field($model, 'clave')->textInput(['maxlength' => true, 'value' => '']) ?>
     <?php endif; ?>
     <div class="form-group">

--- a/views/usuario/_form.php
+++ b/views/usuario/_form.php
@@ -19,6 +19,9 @@ use yii\widgets\ActiveForm;
             ->indexBy('idRol')
             ->column())?>
 
+    <?php if ($is_create): ?>
+        <?= $form->field($model, 'clave')->textInput(['maxlength' => true, 'value' => '']) ?>
+    <?php endif; ?>
     <div class="form-group">
         <?= Html::submitButton('Save', ['class' => 'btn btn-success']) ?>
     </div>

--- a/views/usuario/create.php
+++ b/views/usuario/create.php
@@ -15,6 +15,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
     <?= $this->render('_form', [
         'model' => $model,
+        'is_create' => true,
     ]) ?>
 
 </div>

--- a/views/usuario/index.php
+++ b/views/usuario/index.php
@@ -29,7 +29,6 @@ $this->params['breadcrumbs'][] = $this->title;
 
             'idUsuario',
             'nombreUsuario',
-            'clave',
             'idRol0.nombre',
 
             ['class' => 'yii\grid\ActionColumn'],

--- a/views/usuario/set-password.php
+++ b/views/usuario/set-password.php
@@ -1,0 +1,18 @@
+<?php
+    use yii\helpers\Html;
+    use yii\widgets\ActiveForm;
+?>
+
+<div class="usuario-form">
+
+    <?php $form = ActiveForm::begin(); ?>
+
+    <?= $form->field($model, 'clave')->textInput(['maxlength' => true, 'value' => '']) ?>
+
+    <div class="form-group">
+        <?= Html::submitButton('Save', ['class' => 'btn btn-success']) ?>
+    </div>
+
+    <?php ActiveForm::end(); ?>
+
+</div>

--- a/views/usuario/view.php
+++ b/views/usuario/view.php
@@ -17,6 +17,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
     <p>
         <?= Html::a('Update', ['update', 'id' => $model->idUsuario], ['class' => 'btn btn-primary']) ?>
+        <?= Html::a('Cambiar clave', ['set-password', 'id' => $model->idUsuario], ['class' => 'btn btn-info']) ?>
         <?=
         Html::a('Delete', ['delete', 'id' => $model->idUsuario], [
             'class' => 'btn btn-danger',
@@ -34,7 +35,6 @@ $this->params['breadcrumbs'][] = $this->title;
         'attributes' => [
             'idUsuario',
             'nombreUsuario',
-            'clave',
             'idRol0.nombre',
         ],
     ])


### PR DESCRIPTION
Se propone proteger las claves en la base de datos mediante el algoritmo `bcrypt` que utiliza por defecto Yii.

Se contemplan los siguientes puntos:

**Comando para transformar todas las claves de los usuarios actuales**
El comando `yii users-hash-password/index`. El mismo contempla realizar un chunk cada 100 usuarios. La verdad que se puede mejorar, pero como está destinado a ejecutar una sola vez, no me preocupe tanto.

**Comprobación de clave**
Cambio en el método de comprobación de claves utilizando `validatePassword`

**Actualización de clave y creación de usuarios**
- Al guardar el usuario la contraseña debe pasar por la función hash.
- Al intentar recuperar la clave, el sistema de recuperación de contraseña debe enviar el correo con la clave en texto plano, sin embargo, en la base de datos se guarda el hash.
- Nueva vista de cambiar contraseña para el administrador, separada de los datos de usuario
- En la vista de lista de usuarios, la columna de clave ya no sirve más, es retirada de la vista.